### PR TITLE
fix for api key not found in .env

### DIFF
--- a/.github/workflows/python-poetry.yml
+++ b/.github/workflows/python-poetry.yml
@@ -47,9 +47,9 @@ jobs:
                 --remove-all-unused-imports
     - name: Run pyupgrade
       run: poetry run pyupgrade $(git ls-files "*.py")
-    - name: Test no API_KEY
+    - name: Test no PDL_API_KEY
       run: poetry run pytest -k "not test_api_endpoint_"
-    - name: Test with API_KEY
+    - name: Test with PDL_API_KEY
       run: poetry run pytest -k "test_api_endpoint_"
       env:
-        API_KEY: ${{ secrets.PDL_API_KEY }}
+        PDL_API_KEY: ${{ secrets.PDL_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ if result.ok:
 else:
     print(
         f"Status: {result.status_code};"
-        f"Reason: {result.reason};"
-        f"Message: {result.json()['error']['message']};"
+        f"\nReason: {result.reason};"
+        f"\nMessage: {result.json()['error']['message']};"
     )
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 <img src="https://i.imgur.com/S7DkZtr.png" width="250" alt="People Data Labs Logo">
 </p>
 <h1 align="center">People Data Labs Python Client</h1>
-<p align="center">
-A Python client for the People Data Labs API.
-</p>
+<p align="center">A Python client for the People Data Labs API.</p>
 
 <p align="center">
   <a href="https://github.com/peopledatalabs/peopledatalabs-python">
@@ -22,6 +20,7 @@ A Python client for the People Data Labs API.
 </p>
 
 ## Table of Contents
+
 - [🔧 Installation](#installation)
 - [🚀 Usage](#usage)
 - [🌐 Endpoints](#endpoints)
@@ -35,29 +34,34 @@ A Python client for the People Data Labs API.
     pip install peopledatalabs-python
     ```
 
-2. Sign up for a [free PDL API key](https://www.peopledatalabs.com/signup)
+2. Sign up for a [free PDL API key](https://www.peopledatalabs.com/signup).
+3. Set your API key in the `PDL_API_KEY` environment variable.
 
 ## 🚀 Usage <a name="usage"></a>
 
 First, create the PDLPY client:
+
 ```python
 from peopledatalabs_python import PDLPY
 
 
 # specifying an API key
 client = PDLPY(
-    api_key="YOUR API KEY"
+    api_key="YOUR API KEY",
 )
 
 # or leave blank if you have PDL_API_KEY set in your environment or .env file
 client = PDLPY()
 ```
 
-Then, send requests to any PDL API Endpoint:
+**Note:** You can provide your API key directly in code, or alternatively set a `PDL_API_KEY` variable in your environment or `.env` file.
+
+Then, send requests to any PDL API Endpoint.
 
 ### Getting Person Data
 
 #### By Enrichment
+
 ```python
 result = client.person.enrichment(
     phone="4155688415",
@@ -68,11 +72,13 @@ if result.ok:
 else:
     print(
         f"Status: {result.status_code};"
-        f" Reason: {result.reason};"
-        " Message: {};".format(result.json()["error"]["message"])
+        f"Reason: {result.reason};"
+        f"Message: {result.json()['error']['message']};"
     )
 ```
+
 #### By Bulk Enrichment
+
 ```python
 result = client.person.bulk(
     required="emails AND profiles",
@@ -84,7 +90,7 @@ result = client.person.bulk(
             "params": {
                 "profile": ["linkedin.com/in/seanthorne"],
                 "location": ["SF Bay Area"],
-                "name": ["Sean F. Thorne"]
+                "name": ["Sean F. Thorne"],
             }
         },
         {
@@ -94,7 +100,7 @@ result = client.person.bulk(
             "params": {
                 "profile": ["https://www.linkedin.com/in/haydenconrad/"],
                 "first_name": "Hayden",
-                "last_name": "Conrad"
+                "last_name": "Conrad",
             }
         }
     ]
@@ -103,19 +109,21 @@ if result.ok:
     print(result.text)
 else:
     print(
-        f"Status: {result.status_code};"
-        f" Reason: {result.reason};"
-        " Message: {};".format(result.json()["error"]["message"])
+        f"Status: {result.status_code}"
+        f"\nReason: {result.reason}"
+        f"\nMessage: {result.json()['error']['message']}"
     )
 ```
+
 #### By Search (Elasticsearch)
+
 ```python
 es_query = {
     "query": {
         "bool": {
             "must": [
                 {"term": {"location_country": "mexico"}},
-                {"term": {"job_title_role": "health"}}
+                {"term": {"job_title_role": "health"}},
             ]
         }
     }
@@ -131,12 +139,14 @@ if result.ok:
     print(result.text)
 else:
     print(
-        f"Status: {result.status_code};"
-        f" Reason: {result.reason};"
-        " Message: {};".format(result.json()["error"]["message"])
+        f"Status: {result.status_code}"
+        f"\nReason: {result.reason}"
+        f"\nMessage: {result.json()['error']['message']}"
     )
 ```
+
 #### By Search (SQL)
+
 ```python
 sql_query = (
     "SELECT * FROM person"
@@ -155,26 +165,30 @@ if result.ok:
     print(result.text)
 else:
     print(
-        f"Status: {result.status_code};"
-        f" Reason: {result.reason};"
-        " Message: {};".format(result.json()["error"]["message"])
+        f"Status: {result.status_code}"
+        f"\nReason: {result.reason}"
+        f"\nMessage: {result.json()['error']['message']}"
     )
 ```
+
 #### By `PDL_ID` (Retrieve API)
+
 ```python
 result = client.person.retrieve(
-    person_id="qEnOZ5Oh0poWnQ1luFBfVw_0000"
+    person_id="qEnOZ5Oh0poWnQ1luFBfVw_0000",
 )
 if result.ok:
     print(result.text)
 else:
     print(
-        f"Status: {result.status_code};"
-        f" Reason: {result.reason};"
-        " Message: {};".format(result.json()["error"]["message"])
+        f"Status: {result.status_code}"
+        f"\nReason: {result.reason}"
+        f"\nMessage: {result.json()['error']['message']}"
     )
 ```
+
 #### By Fuzzy Enrichment (Identify API)
+
 ```python
 result = client.person.enrichment(
     name="sean thorne",
@@ -184,29 +198,33 @@ if result.ok:
     print(result.text)
 else:
     print(
-        f"Status: {result.status_code};"
-        f" Reason: {result.reason};"
-        " Message: {};".format(result.json()["error"]["message"])
+        f"Status: {result.status_code}"
+        f"\nReason: {result.reason}"
+        f"\nMessage: {result.json()['error']['message']}"
     )
 ```
 
 ### Getting Company Data
+
 #### By Enrichment
+
 ```python
 result = client.company.enrichment(
     website="peopledatalabs.com",
-    pretty=True
+    pretty=True,
 )
 if result.ok:
     print(result.text)
 else:
     print(
-        f"Status: {result.status_code};"
-        f" Reason: {result.reason};"
-        " Message: {};".format(result.json()["error"]["message"])
+        f"Status: {result.status_code}"
+        f"\nReason: {result.reason}"
+        f"\nMessage: {result.json()['error']['message']}"
     )
 ```
+
 #### By Search (Elasticsearch)
+
 ```python
 es_query = {
     "query": {
@@ -229,12 +247,14 @@ if result.ok:
     print(result.text)
 else:
     print(
-        f"Status: {result.status_code};"
-        f" Reason: {result.reason};"
-        " Message: {};".format(result.json()["error"]["message"])
+        f"Status: {result.status_code}"
+        f"\nReason: {result.reason}"
+        f"\nMessage: {result.json()['error']['message']}"
     )
 ```
+
 #### By Search (SQL)
+
 ```python
 sql_query = (
     "SELECT * FROM company"
@@ -252,14 +272,16 @@ if result.ok:
     print(result.text)
 else:
     print(
-        f"Status: {result.status_code};"
-        f" Reason: {result.reason};"
-        " Message: {};".format(result.json()["error"]["message"])
+        f"Status: {result.status_code}"
+        f"\nReason: {result.reason}"
+        f"\nMessage: {result.json()['error']['message']}"
     )
 ```
+
 ### Using supporting APIs
 
 #### Get Autocomplete Suggestions
+
 ```python
 result = client.autocomplete(
     field="title",
@@ -270,83 +292,87 @@ if result.ok:
     print(result.text)
 else:
     print(
-        f"Status: {result.status_code};"
-        f" Reason: {result.reason};"
-        " Message: {};".format(result.json()["error"]["message"])
+        f"Status: {result.status_code}"
+        f"\nReason: {result.reason}"
+        f"\nMessage: {result.json()['error']['message']}"
     )
 ```
 
 #### Clean Raw Company Strings
+
 ```python
 result = client.company.cleaner(
-    name="peOple DaTa LabS"
+    name="peOple DaTa LabS",
 )
 if result.ok:
     print(result.text)
 else:
     print(
-        f"Status: {result.status_code};"
-        f" Reason: {result.reason};"
-        " Message: {};".format(result.json()["error"]["message"])
+        f"Status: {result.status_code}"
+        f"\nReason: {result.reason}"
+        f"\nMessage: {result.json()['error']['message']}"
     )
 ```
 
 #### Clean Raw Location Strings
+
 ```python
 result = client.location.cleaner(
-    location="455 Market Street, San Francisco, California 94105, US"
+    location="455 Market Street, San Francisco, California 94105, US",
 )
 if result.ok:
     print(result.text)
 else:
     print(
-        f"Status: {result.status_code};"
-        f" Reason: {result.reason};"
-        " Message: {};".format(result.json()["error"]["message"])
+        f"Status: {result.status_code}"
+        f"\nReason: {result.reason}"
+        f"\nMessage: {result.json()['error']['message']}"
     )
 ```
 
 #### Clean Raw School Strings
+
 ```python
 result = client.school.cleaner(
-    name="university of oregon"
+    name="university of oregon",
 )
 if result.ok:
     print(result.text)
 else:
     print(
-        f"Status: {result.status_code};"
-        f" Reason: {result.reason};"
-        " Message: {};".format(result.json()["error"]["message"])
+        f"Status: {result.status_code}"
+        f"\nReason: {result.reason}"
+        f"\nMessage: {result.json()['error']['message']}"
     )
 ```
+
 ## 🌐 Endpoints <a name="endpoints"></a>
 
 **Person Endpoints**
 
-| API Endpoint | PDLPY Function |
-|-|-|
-| [Person Enrichment API](https://docs.peopledatalabs.com/docs/enrichment-api) | `PDLPY.person.enrichment(**params)`
-| [Person Bulk Enrichment API](https://docs.peopledatalabs.com/docs/bulk-enrichment-api) | `PDLPY.person.bulk(**params)`
-| [Person Search API](https://docs.peopledatalabs.com/docs/search-api) | `PDLPY.person.search(**params)`
-| [Person Retrieve API](https://docs.peopledatalabs.com/docs/person-retrieve-api) | `PDLPY.person.retrieve(**params)`
-| [Person Identify API](https://docs.peopledatalabs.com/docs/identify-api) | `PDLPY.person.identify(**params)` |
+| API Endpoint                                                                           | PDLPY Function                      |
+| -------------------------------------------------------------------------------------- | ----------------------------------- |
+| [Person Enrichment API](https://docs.peopledatalabs.com/docs/enrichment-api)           | `PDLPY.person.enrichment(**params)` |
+| [Person Bulk Enrichment API](https://docs.peopledatalabs.com/docs/bulk-enrichment-api) | `PDLPY.person.bulk(**params)`       |
+| [Person Search API](https://docs.peopledatalabs.com/docs/search-api)                   | `PDLPY.person.search(**params)`     |
+| [Person Retrieve API](https://docs.peopledatalabs.com/docs/person-retrieve-api)        | `PDLPY.person.retrieve(**params)`   |
+| [Person Identify API](https://docs.peopledatalabs.com/docs/identify-api)               | `PDLPY.person.identify(**params)`   |
 
 **Company Endpoints**
 
-| API Endpoint | PDLPY Function |
-|-|-|
+| API Endpoint                                                                          | PDLPY Function                       |
+| ------------------------------------------------------------------------------------- | ------------------------------------ |
 | [Company Enrichment API](https://docs.peopledatalabs.com/docs/company-enrichment-api) | `PDLPY.company.enrichment(**params)` |
-| [Company Search API](https://docs.peopledatalabs.com/docs/company-search-api) | `PDLPY.company.search(**params)` |
+| [Company Search API](https://docs.peopledatalabs.com/docs/company-search-api)         | `PDLPY.company.search(**params)`     |
 
 **Supporting Endpoints**
 
-| API Endpoint | PDLJS Function |
-|-|-|
-| [Autocomplete API](https://docs.peopledatalabs.com/docs/autocomplete-api) | `PDLPY.autocomplete(**params)` |
-| [Company Cleaner API](https://docs.peopledatalabs.com/docs/cleaner-apis#companyclean) | `PDLPY.company.cleaner(**params)` |
+| API Endpoint                                                                            | PDLJS Function                     |
+| --------------------------------------------------------------------------------------- | ---------------------------------- |
+| [Autocomplete API](https://docs.peopledatalabs.com/docs/autocomplete-api)               | `PDLPY.autocomplete(**params)`     |
+| [Company Cleaner API](https://docs.peopledatalabs.com/docs/cleaner-apis#companyclean)   | `PDLPY.company.cleaner(**params)`  |
 | [Location Cleaner API](https://docs.peopledatalabs.com/docs/cleaner-apis#locationclean) | `PDLPY.location.cleaner(**params)` |
-| [School Cleaner API](https://docs.peopledatalabs.com/docs/cleaner-apis#schoolclean) | `PDLPY.school.cleaner(**params)` |
+| [School Cleaner API](https://docs.peopledatalabs.com/docs/cleaner-apis#schoolclean)     | `PDLPY.school.cleaner(**params)`   |
 
 
 ## 📘 Documentation <a name="documentation"></a>
@@ -360,11 +386,13 @@ As illustrated in the [Endpoints](#endpoints) section above, each of our API end
 As an example:
 
 The following is **valid** because `name` is a [supported input parameter to the Person Identify API](https://docs.peopledatalabs.com/docs/identify-api-reference#input-parameters):
+
 ```python
-PDLPY().person.identify({ name: 'sean thorne' })
+PDLPY().person.identify({"name": "sean thorne"})
 ```
 
 Conversely, this would be **invalid** because `fake_parameter` is not an input parameter to the Person Identify API:
+
 ```python
-PDLPY().person.identify({ fake_parameter: 'anything' })
+PDLPY().person.identify({"fake_parameter": "anything"})
 ```

--- a/README.md
+++ b/README.md
@@ -46,11 +46,10 @@ from peopledatalabs_python import PDLPY
 
 # specifying an API key
 client = PDLPY(
-  api_key="YOUR API KEY"
+    api_key="YOUR API KEY"
 )
 
-# or leave blank if you have API_KEY set in your environment
-# (or in a .env file)
+# or leave blank if you have PDL_API_KEY set in your environment or .env file
 client = PDLPY()
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "peopledatalabs-python"
-version = "1.0.0"
+version = "1.0.1"
 description = "Python client for the People Data Labs API"
 homepage = "https://www.peopledatalabs.com"
 repository = "https://github.com/peopledatalabs/peopledatalabs-python"

--- a/src/peopledatalabs_python/main.py
+++ b/src/peopledatalabs_python/main.py
@@ -55,7 +55,7 @@ class PDLPY:
         if v is None:
             raise ValueError(
                 "Please enter a value for API key, or define it either in"
-                " your environment or .env file as API_KEY"
+                " your environment or .env file as PDL_API_KEY"
             )
         return v
 

--- a/src/peopledatalabs_python/requests.py
+++ b/src/peopledatalabs_python/requests.py
@@ -54,7 +54,7 @@ class Request:
         """
         Executes a GET request from the specified API.
 
-        User's API_KEY is sent in request parameters.
+        User's PDL_API_KEY is sent in request parameters.
 
         Returns:
             A requests.Response object with the result of the HTTP call.
@@ -72,7 +72,7 @@ class Request:
         """
         Executes a POST request to the specified API.
 
-        User's API_KEY is sent as a 'X-api-key' header.
+        User's PDL_API_KEY is sent as a 'X-api-key' header.
 
         Returns:
             A requests.Response object with the result of the HTTP call.

--- a/src/peopledatalabs_python/settings.py
+++ b/src/peopledatalabs_python/settings.py
@@ -7,7 +7,7 @@ file.
 
 import os
 
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 from pydantic import HttpUrl, SecretStr
 from pydantic.dataclasses import dataclass
 
@@ -29,9 +29,12 @@ class Settings:
     version_re: str = r"^v[0-9]$"
 
     def __post_init__(self):
-        load_dotenv()
+        load_dotenv(dotenv_path=find_dotenv(usecwd=True))
         for key in self.__dict__:
-            self.__dict__[key] = os.getenv(key.upper(), self.__dict__[key])
+            if key == "api_key":
+                self.__dict__[key] = os.getenv("PDL_API_KEY", self.__dict__[key])
+            else:
+                self.__dict__[key] = os.getenv(key.upper(), self.__dict__[key])
 
 
 settings = Settings()

--- a/src/peopledatalabs_python/settings.py
+++ b/src/peopledatalabs_python/settings.py
@@ -32,7 +32,7 @@ class Settings:
         load_dotenv(dotenv_path=find_dotenv(usecwd=True))
         for key in self.__dict__:
             if key == "api_key":
-                self.__dict__[key] = os.getenv("PDL_API_KEY", self.__dict__[key])
+                self.api_key = os.getenv("PDL_API_KEY", self.api_key)
             else:
                 self.__dict__[key] = os.getenv(key.upper(), self.__dict__[key])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def fixture_fake_api_key():
 @pytest.fixture
 def client():
     """
-    Client instance loads API_KEY from .env file.
+    Client instance loads PDL_API_KEY from .env file.
     """
     return PDLPY()
 


### PR DESCRIPTION
## Description of the change

- rename API_KEY env variable to PDL_API_KEY since it's more compatible with other api keys customers might be using
- use `find_dotenv(usecwd=True)` since settings are not able to find the `.env` file when installing peopledatalabs-python as an external package

### Context

When installing `peopledatalabs-python`, the package is not able to find the api key in the `.env` file in the root of the repo. Unfortunately I'm not sure how to add a test for this since it apparently works fine when running the code as first-party.

#### Steps to reproduce

```
$ poetry new foobar
$ cd foobar
$ poetry add peopledatalabs-python
$ echo "API_KEY=XXX" > .env
$ echo "from peopledatalabs_python import PDLPY" >> foobar/__init__.py 
$ echo "PDLPY()" >> foobar/__init__.py
$ poetry run python foobar/__init__.py                               
Traceback (most recent call last):
  File "/Users/martim/foobar/foobar/__init__.py", line 2, in <module>
    PDLPY()
  File "<string>", line 7, in __init__
  File "pydantic/dataclasses.py", line 100, in pydantic.dataclasses._generate_pydantic_post_init._pydantic_post_init
    # +=======+=======+=======+
pydantic.error_wrappers.ValidationError: 1 validation error for PDLPY
api_key
  Please enter a value for API key, or define it either in your environment or .env file as API_KEY (type=value_error)
```

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Chore (cleanup or minor QOL tweak that has little to no impact on functionality)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
