### PR TITLE
Be more forgiving when using python-dotenv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 python = "^3.7.2"
 email-validator = "^1.1"
 pydantic = "^1.8"
-python-dotenv = "^0.13"
+python-dotenv = "^0"
 requests = "^2"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
## Description of the change

Allow any version beginning with 0. for python-dotenv.  This will allow downstream consumers like me to use the latest version of dotenv...

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Chore (cleanup or minor QOL tweak that has little to no impact on functionality)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
