### PR TITLE
Affix pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.7.2"
 email-validator = "^1.1"
-pydantic = "^1.8"
+pydantic = "^1.8.2"
 python-dotenv = "^0.13"
 requests = "^2"
 


### PR DESCRIPTION
## Description of the change

Pydantic 1.10 introduces some breaking changes resulting in an invalid call to __post_init_post_parse__

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Chore (cleanup or minor QOL tweak that has little to no impact on functionality)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
