### PR TITLE
Bug fix for issue 21: Env VERSION collision

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "peopledatalabs"
-version = "1.1.1"
+version = "1.1.2"
 description = "Official Python client for the People Data Labs API"
 homepage = "https://www.peopledatalabs.com"
 repository = "https://github.com/peopledatalabs/peopledatalabs-python"

--- a/src/peopledatalabs/__init__.py
+++ b/src/peopledatalabs/__init__.py
@@ -6,6 +6,6 @@ PeopleDataLabs Python Client.
 from .main import PDLPY
 
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 __all__ = ["PDLPY"]

--- a/src/peopledatalabs/settings.py
+++ b/src/peopledatalabs/settings.py
@@ -34,7 +34,7 @@ class Settings:
     def __post_init__(self):
         load_dotenv(dotenv_path=find_dotenv(usecwd=True))
         for key in self.__dict__:
-            env_key = "PDL_"+key.upper()
+            env_key = "PDL_" + key.upper()
             self.__dict__[key] = os.getenv(env_key, self.__dict__[key])
 
 

--- a/src/peopledatalabs/settings.py
+++ b/src/peopledatalabs/settings.py
@@ -19,6 +19,8 @@ class Settings:
 
     Settings are eventually overridden if a .env file is provided, or
     environment variables are defined.
+
+    All env variables should be in the form of PDL_<setting name>
     """
 
     api_key: SecretStr = None
@@ -32,10 +34,7 @@ class Settings:
     def __post_init__(self):
         load_dotenv(dotenv_path=find_dotenv(usecwd=True))
         for key in self.__dict__:
-            if key == "api_key":
-                self.api_key = os.getenv("PDL_API_KEY", self.api_key)
-            else:
-                self.__dict__[key] = os.getenv(key.upper(), self.__dict__[key])
+                self.__dict__[key] = os.getenv("PDL_"+key.upper(), self.__dict__[key])
 
 
 settings = Settings()

--- a/src/peopledatalabs/settings.py
+++ b/src/peopledatalabs/settings.py
@@ -34,7 +34,8 @@ class Settings:
     def __post_init__(self):
         load_dotenv(dotenv_path=find_dotenv(usecwd=True))
         for key in self.__dict__:
-                self.__dict__[key] = os.getenv("PDL_"+key.upper(), self.__dict__[key])
+            env_key = "PDL_"+key.upper()
+            self.__dict__[key] = os.getenv(env_key, self.__dict__[key])
 
 
 settings = Settings()

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -20,7 +20,7 @@ def test_version():
     """
     Version check.
     """
-    assert __version__ == "1.1.1"
+    assert __version__ == "1.1.2"
 
 
 @pytest.mark.usefixtures("fake_api_key")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ Pytest testing configuration file.
 
 import uuid
 
+import os
+
 import pytest
 
 from peopledatalabs.main import PDLPY
@@ -46,15 +48,11 @@ def client_sandbox_enabled():
     return PDLPY(sandbox=True)
 
 @pytest.fixture
-def client_sandbox_enabled():
+def client_env_test():
     """
     Client instance loads correct env variables
     """
-
-    import os
     os.environ["VERSION"] = "PDL_TEST_FAIL"
     os.environ["PDL_VERSION"] = "v6"
-    p = PDLPY(sandbox=True)
-    
-    return p.version == "v6"
-    
+    p_i = PDLPY(sandbox=True)
+    return p_i.version == "v6"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ def client_sandbox_enabled():
 @pytest.fixture
 def client_env_test():
     """
-    Client instance loads correct env variables
+    Client instance loads correct env variables.
     """
     os.environ["VERSION"] = "PDL_TEST_FAIL"
     os.environ["PDL_VERSION"] = "v6"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,5 +55,10 @@ def client_env_test():
     """
     os.environ["VERSION"] = "PDL_TEST_FAIL"
     os.environ["PDL_VERSION"] = "v6"
+
     p_i = PDLPY(sandbox=True)
+
+    del os.environ['VERSION']
+    del os.environ['PDL_VERSION']
+    
     return p_i.version == "v6"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,7 @@ def client_sandbox_enabled():
     """
     return PDLPY(sandbox=True)
 
+
 @pytest.fixture
 def client_env_test():
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,3 +44,17 @@ def client_sandbox_enabled():
     Client instance loads PDL_API_KEY from .env file and Sandbox enabled.
     """
     return PDLPY(sandbox=True)
+
+@pytest.fixture
+def client_sandbox_enabled():
+    """
+    Client instance loads correct env variables
+    """
+
+    import os
+    os.environ["VERSION"] = "PDL_TEST_FAIL"
+    os.environ["PDL_VERSION"] = "v6"
+    p = PDLPY(sandbox=True)
+    
+    return p.version == "v6"
+    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def client_env_test():
 
     p_i = PDLPY(sandbox=True)
 
-    del os.environ['VERSION']
-    del os.environ['PDL_VERSION']
-    
+    del os.environ["VERSION"]
+    del os.environ["PDL_VERSION"]
+
     return p_i.version == "v6"


### PR DESCRIPTION
## Description of the change

> SDK Settings class tries to load environment variables matching internal settings variables. This can cause a clash as
standard env variables like VERSION will be loaded. 

This changes the naming scheme to avoid this type of collision across all variables. Only variables starting "PDL_<*>"

Ex: "PDL_VERSION"

Fixes #21.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Chore (cleanup or minor QOL tweak that has little to no impact on functionality)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
